### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/SlowSwitcher/keywords.txt
+++ b/SlowSwitcher/keywords.txt
@@ -10,9 +10,9 @@ SlowSwitcher	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-read    KEYWORD2
-isSwitching KEYWORD2
-write   KEYWORD2
+read	KEYWORD2
+isSwitching	KEYWORD2
+write	KEYWORD2
 update	KEYWORD2
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords